### PR TITLE
Disable the request timeout on generated gateway routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ the destination cluster. The base domain is used as the backend SNI and is
 validated against the backend certificate using system certificate authorities.
 The generated route selects the Envoy `Backend` port explicitly, and the backend
 TLS policy targets the same port by its numeric section name.
+
+The generated HTTPS route disables the Gateway API request timeout. Envoy
+otherwise applies a 15 second timeout covering the whole request-response
+transaction, which truncates large uploads and long-lived media streams even
+while they are actively transferring. A destination cluster ingress typically
+bounds idle time instead of total duration, so the registration would otherwise
+impose a limit the cluster did not have before it was fronted by the gateway.
+Envoy's stream idle timeout is unaffected and still closes stalled connections.

--- a/gateway.tf
+++ b/gateway.tf
@@ -12,6 +12,7 @@ locals {
   gateway_listener_https_apex         = "https-apex"
   gateway_listener_https_wildcard     = "https-wildcard"
   gateway_private_key_rotation_policy = "Always"
+  gateway_request_timeout             = "0s"
   gateway_route_manifest_name         = "routing.yaml"
   gateway_routing_namespace           = "routing"
   gateway_system_ca_name              = "System"
@@ -44,6 +45,7 @@ locals {
       listener_https_apex         = local.gateway_listener_https_apex
       listener_https_wildcard     = local.gateway_listener_https_wildcard
       private_key_rotation_policy = local.gateway_private_key_rotation_policy
+      request_timeout             = local.gateway_request_timeout
       routing_namespace           = local.gateway_routing_namespace
       system_ca_name              = local.gateway_system_ca_name
       tls_mode                    = local.gateway_tls_mode

--- a/gateway_route.tftpl
+++ b/gateway_route.tftpl
@@ -104,6 +104,14 @@ spec:
           kind: Backend
           name: ${gateway_name}
           port: ${backend_port}
+      # Envoy applies a 15s timeout covering the whole request-response
+      # transaction when this is unset, which truncates large uploads and
+      # long-lived media streams. The destination cluster ingress caps idle
+      # time rather than total duration. "0s" disables the cap and matches
+      # that behavior; Envoy's stream idle timeout still closes genuinely
+      # stalled connections.
+      timeouts:
+        request: "${request_timeout}"
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha3
 kind: BackendTLSPolicy


### PR DESCRIPTION
## Problem

Envoy applies a **15 second timeout covering the whole request-response transaction** when an `HTTPRoute` rule does not set one. The generated HTTPS route never set it.

Registered clusters sit behind an ingress that bounds *idle* time rather than *total* duration, so registering a cluster with the gateway imposed a limit it did not have before it was fronted. Large uploads and long-lived media streams were truncated at 15 seconds even while actively transferring, which presents to users as a request body size limit rather than a timeout.

Observed on `photos.reisman.org` (Immich) and `books.reisman.org` (Audiobookshelf), both of which already had `nginx.ingress.kubernetes.io/proxy-body-size: "0"` — so no body limit was in play.

## Change

Emit `timeouts.request` on the generated HTTPS route from a new `gateway_request_timeout` module constant, set to `"0s"`.

Per the Gateway API spec, `"0s"` disables the timeout completely, and the CEL validation on `HTTPRouteTimeouts` explicitly special-cases it. Envoy's stream idle timeout is unaffected and still closes genuinely stalled connections, so this restores the pre-gateway behavior rather than removing all protection.

It is a constant rather than a variable because the 15s cap is wrong for every cluster this module registers, not a per-cluster preference. Promoting it to a variable is a two-line change if per-cluster tuning is ever wanted.

## Verification

- Rendered the template with production's values: parses as 6 YAML documents, `timeouts: {request: "0s"}` on the correct route.
- Template variable coverage is exact — no reference without a value, no value unused.
- `=` alignment checked in both the locals block and the template map.
- Rendered output is **byte-identical** to the live `routes/production/routing.yaml`, so applying this is a no-op on that file rather than reverting the hand-applied fix.

`terraform fmt`/`validate`/`plan` were not run — Terraform is not installed on the machine this was written on. Worth a `plan` before applying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)